### PR TITLE
Remove portal-vue and vuejs-dialog as dependencies since COSMOS remov…

### DIFF
--- a/cosmosc2-tool-planetviewer/src/main.js
+++ b/cosmosc2-tool-planetviewer/src/main.js
@@ -1,6 +1,5 @@
 import './set-public-path'
 import Vue from 'vue'
-import VuejsDialog from 'vuejs-dialog'
 import singleSpaVue from 'single-spa-vue'
 
 import App from './App.vue'
@@ -17,11 +16,7 @@ Vue.config.productionTip = false
 
 import '@cosmosc2/tool-common/src/assets/stylesheets/layout/layout.scss'
 import vuetify from './plugins/vuetify'
-import 'vuejs-dialog/dist/vuejs-dialog.min.css'
-import PortalVue from 'portal-vue'
 
-Vue.use(PortalVue)
-Vue.use(VuejsDialog)
 
 const vueLifecycles = singleSpaVue({
   Vue,

--- a/cosmosc2-tool-planetviewer/vue.config.js
+++ b/cosmosc2-tool-planetviewer/vue.config.js
@@ -58,9 +58,7 @@ module.exports = {
         }
       })
     config.externals([
-      'portal-vue',
       'vue',
-      'vuejs-dialog',
       'vuetify',
       'vuex',
       'vue-router',


### PR DESCRIPTION
Looks like COSMOS past 5.0.1 removed portal-vue and vuejs-dialog. Since these are gone, planetviewer cannot load because it is looking for those dependencies.

1. Remove portal-vue
2. Remove vuejs-dialog

The following commits removed these dependencies from COSMOS

[remove vuuejs-dialog as external](https://github.com/BallAerospace/COSMOS/commit/95cc9008cca31c995759fe3ca8eee67da01347d2)
[remove portal-vue as external](https://github.com/BallAerospace/COSMOS/commit/cd39e6fd2e922eb537289ae7e552be76871ac2c2)

I would get the following errors:
```
Uncaught Error: application '@cosmosc2/tool-planetviewer' died in status LOADING_SOURCE_CODE: Unable to resolve bare specifier 'portal-vue' from http://cosmos-002:2900/tools/planetviewer/js/app.js (SystemJS Error#8 https://git.io/JvFET#8)
    resolve http://cosmos-002:2900/js/system-6.12.1.min.js:1
    resolve http://cosmos-002:2900/js/system-6.12.1.min.js:1
    resolve http://cosmos-002:2900/js/named-register.min.js:1
    c http://cosmos-002:2900/js/system-6.12.1.min.js:1
    c http://cosmos-002:2900/js/system-6.12.1.min.js:1
system-6.12.1.min.js:1:7801
    resolve http://cosmos-002:2900/js/system-6.12.1.min.js:1
    resolve http://cosmos-002:2900/js/system-6.12.1.min.js:1
    resolve http://cosmos-002:2900/js/named-register.min.js:1
    c http://cosmos-002:2900/js/system-6.12.1.min.js:1
    map self-hosted:218
    c http://cosmos-002:2900/js/system-6.12.1.min.js:1
```
    
and I also get this error:
    
```
    Uncaught Error: application '@cosmosc2/tool-planetviewer' died in status LOADING_SOURCE_CODE: application '@cosmosc2/tool-planetviewer' died in status LOADING_SOURCE_CODE: Unable to resolve bare specifier 'portal-vue' from http://cosmos-002:2900/tools/planetviewer/js/app.js (SystemJS Error#8 https://git.io/JvFET#8)
    resolve http://cosmos-002:2900/js/system-6.12.1.min.js:1
    resolve http://cosmos-002:2900/js/system-6.12.1.min.js:1
    resolve http://cosmos-002:2900/js/named-register.min.js:1
    c http://cosmos-002:2900/js/system-6.12.1.min.js:1
    c http://cosmos-002:2900/js/system-6.12.1.min.js:1
```
    
I removed `portal-vue` and `vuejs-dialog`, built with the following commands in a virtual environment:

```
yarn
...
yarn build
...
rake build VERSION=5.0.5
```

Once built, I uploaded the GEM to COSMOS 5.0.5 in the admin tool.